### PR TITLE
Update Codecov badge to point to correct repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CI Status](https://github.com/AY2526S2-CS2103T-T17-1/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2526S2-CS2103T-T17-1/tp/actions)
-[![codecov](https://codecov.io/gh/CS2103T-T17-1/tp/graph/badge.svg?token=DU35S1U7NP)](https://codecov.io/gh/CS2103T-T17-1/tp)
+[![codecov](https://codecov.io/gh/AY2526S2-CS2103T-T17-1/tp/graph/badge.svg?token=DU35S1U7NP)](https://codecov.io/gh/AY2526S2-CS2103T-T17-1/tp)
 
 ![Ui](docs/images/Ui.png)
 


### PR DESCRIPTION
Current CodeCov badge points to the incorrect repo
Lets fix that by
- Making it point to the correct repo in the README.md