### PR TITLE
Commands: Implement list-clients with optional index and Codecov rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
     "java.format.settings.profile": "VSCode",
 
     "editor.codeActionsOnSave": {
-        "source.organizeImports": false
+        "source.organizeImports": "never"
     },
 
     // Import order: static imports come first automatically; then the groups below.
@@ -26,7 +26,7 @@
     "[java]": {
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
-            "source.organizeImports": false
+            "source.organizeImports": "never"
         }
     },
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 75%
+        threshold: 0%
+    patch:
+      default:
+        target: 75%
+        threshold: 0%

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -19,13 +19,25 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+    /** The trainer selection in the UI should be cleared. */
+    private final boolean clearTrainer;
+
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, boolean clearTrainer) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
+        this.clearTrainer = clearTrainer;
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
+     * and other fields set to their default value.
+     */
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+        this(feedbackToUser, showHelp, exit, false);
     }
 
     /**
@@ -33,7 +45,7 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false);
+        this(feedbackToUser, false, false, false);
     }
 
     public String getFeedbackToUser() {
@@ -46,6 +58,10 @@ public class CommandResult {
 
     public boolean isExit() {
         return exit;
+    }
+
+    public boolean isClearTrainer() {
+        return clearTrainer;
     }
 
     @Override
@@ -62,12 +78,13 @@ public class CommandResult {
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
-                && exit == otherCommandResult.exit;
+                && exit == otherCommandResult.exit
+                && clearTrainer == otherCommandResult.clearTrainer;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit);
+        return Objects.hash(feedbackToUser, showHelp, exit, clearTrainer);
     }
 
     @Override
@@ -76,6 +93,7 @@ public class CommandResult {
                 .add("feedbackToUser", feedbackToUser)
                 .add("showHelp", showHelp)
                 .add("exit", exit)
+                .add("clearTrainer", clearTrainer)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/ListClientsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListClientsCommand.java
@@ -3,21 +3,90 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import java.util.List;
+import java.util.Optional;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Trainer;
 
 /**
- * Lists all clients in the address book to the user.
+ * Lists clients in the address book to the user.
+ * Without an index, all clients are shown and any trainer selection is cleared.
+ * With an index, shows only clients belonging to the trainer at that index.
  */
 public class ListClientsCommand extends Command {
 
     public static final String COMMAND_WORD = "list-clients";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Lists clients. Without an index, shows all clients and clears trainer selection.\n"
+            + "With a trainer index, shows only clients for that trainer.\n"
+            + "Parameters: [INDEX] (must be a positive integer if provided)\n"
+            + "Example: " + COMMAND_WORD + "\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
     public static final String MESSAGE_SUCCESS = "Listed all clients";
+    public static final String MESSAGE_SUCCESS_TRAINER = "Listed clients for trainer: %1$s";
+    public static final String MESSAGE_INVALID_TRAINER_INDEX = "The trainer index provided is invalid.";
+
+    private final Optional<Index> trainerIndex;
+
+    /**
+     * Creates a ListClientsCommand that shows all clients and clears any trainer selection.
+     */
+    public ListClientsCommand() {
+        this.trainerIndex = Optional.empty();
+    }
+
+    /**
+     * Creates a ListClientsCommand that shows only clients for the trainer at {@code index}.
+     */
+    public ListClientsCommand(Index index) {
+        requireNonNull(index);
+        this.trainerIndex = Optional.of(index);
+    }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        model.updateFilteredClientList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS);
+
+        if (trainerIndex.isEmpty()) {
+            // No index: clear trainer selection and show all clients
+            model.clearSelectedTrainer();
+            model.updateFilteredClientList(PREDICATE_SHOW_ALL_PERSONS);
+            return new CommandResult(MESSAGE_SUCCESS, false, false, true);
+        }
+
+        // With index: select the trainer at the given index
+        List<Person> trainerList = model.getFilteredTrainerList();
+        int zeroBased = trainerIndex.get().getZeroBased();
+
+        if (zeroBased >= trainerList.size()) {
+            throw new CommandException(MESSAGE_INVALID_TRAINER_INDEX);
+        }
+
+        Person person = trainerList.get(zeroBased);
+        if (!(person instanceof Trainer)) {
+            throw new CommandException(MESSAGE_INVALID_TRAINER_INDEX);
+        }
+
+        Trainer trainer = (Trainer) person;
+        model.setSelectedTrainer(trainer);
+        return new CommandResult(String.format(MESSAGE_SUCCESS_TRAINER, trainer.getName()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof ListClientsCommand)) {
+            return false;
+        }
+        ListClientsCommand otherCommand = (ListClientsCommand) other;
+        return trainerIndex.equals(otherCommand.trainerIndex);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -110,7 +110,7 @@ public class AddressBookParser {
             return new ListTrainersCommand();
 
         case ListClientsCommand.COMMAND_WORD:
-            return new ListClientsCommand();
+            return new ListClientsCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/ListClientsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListClientsCommandParser.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.ListClientsCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ListClientsCommand object.
+ */
+public class ListClientsCommandParser implements Parser<ListClientsCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ListClientsCommand
+     * and returns a ListClientsCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListClientsCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            return new ListClientsCommand();
+        }
+
+        try {
+            Index index = ParserUtil.parseIndex(trimmedArgs);
+            return new ListClientsCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListClientsCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -217,6 +217,10 @@ public class MainWindow extends UiPart<Stage> {
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
+            if (commandResult.isClearTrainer()) {
+                trainerListPanel.clearSelection();
+            }
+
             updateClientFilterLinkText();
 
             if (commandResult.isShowHelp()) {

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -57,7 +57,7 @@ public class CommandResultTest {
         CommandResult commandResult = new CommandResult("feedback");
         String expected = CommandResult.class.getCanonicalName() + "{feedbackToUser="
                 + commandResult.getFeedbackToUser() + ", showHelp=" + commandResult.isShowHelp()
-                + ", exit=" + commandResult.isExit() + "}";
+                + ", exit=" + commandResult.isExit() + ", clearTrainer=" + commandResult.isClearTrainer() + "}";
         assertEquals(expected, commandResult.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListClientsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListClientsCommandTest.java
@@ -1,14 +1,20 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.ListClientsCommandParser;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -19,35 +25,133 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Trainer;
+
 public class ListClientsCommandTest {
 
-    @Test
-    public void execute_listIsFiltered_showsAllClients() {
-        AddressBook ab = new AddressBook();
-        Trainer trainer = new Trainer(new Name("Trainer"), new Phone("90000000"), new Email("t@example.com"),
+    private AddressBook ab;
+    private Trainer trainer;
+    private Client clientA;
+    private Client clientB;
+
+    @BeforeEach
+    public void setUp() {
+        ab = new AddressBook();
+        trainer = new Trainer(new Name("Trainer"), new Phone("90000000"), new Email("t@example.com"),
                 new HashSet<>());
-        Client clientA = new Client(new Name("Alice"), new Phone("80000001"), trainer.getPhone(), trainer.getName(),
+        clientA = new Client(new Name("Alice"), new Phone("80000001"), trainer.getPhone(), trainer.getName(),
                 new HashSet<>());
-        Client clientB = new Client(new Name("Bob"), new Phone("80000002"), trainer.getPhone(), trainer.getName(),
+        clientB = new Client(new Name("Bob"), new Phone("80000002"), trainer.getPhone(), trainer.getName(),
                 new HashSet<>());
         ab.addPerson(trainer);
         ab.addPerson(clientA);
         ab.addPerson(clientB);
+    }
 
+    // ──── No-index form ───────────────────────────────────────────────────────
+
+    @Test
+    public void execute_noIndex_showsAllClients() throws CommandException {
         Model model = new ModelManager(ab, new UserPrefs());
         model.updateFilteredClientList(new NameContainsKeywordsPredicate(List.of("Alice")));
 
-        Model expectedModel = new ModelManager(ab, new UserPrefs());
-        expectedModel.updateFilteredClientList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        CommandResult result = new ListClientsCommand().execute(model);
 
-        ListClientsCommand command = new ListClientsCommand();
-        assertCommandSuccess(command, model, ListClientsCommand.MESSAGE_SUCCESS, expectedModel);
+        assertEquals(ListClientsCommand.MESSAGE_SUCCESS, result.getFeedbackToUser());
         assertEquals(2, model.getFilteredClientList().size());
     }
 
     @Test
+    public void execute_noIndex_clearTrainerFlagIsTrue() throws CommandException {
+        Model model = new ModelManager(ab, new UserPrefs());
+        CommandResult result = new ListClientsCommand().execute(model);
+        assertTrue(result.isClearTrainer());
+    }
+
+    @Test
+    public void execute_noIndex_clearsSelectedTrainer() throws CommandException {
+        Model model = new ModelManager(ab, new UserPrefs());
+        model.setSelectedTrainer(trainer);
+
+        new ListClientsCommand().execute(model);
+
+        assertTrue(model.getSelectedTrainer().isEmpty());
+    }
+
+    // ──── With-index form ─────────────────────────────────────────────────────
+
+    @Test
+    public void execute_withIndex_showsOnlyTrainersClients() throws CommandException {
+        Model model = new ModelManager(ab, new UserPrefs());
+
+        CommandResult result = new ListClientsCommand(Index.fromOneBased(1)).execute(model);
+
+        assertEquals(String.format(ListClientsCommand.MESSAGE_SUCCESS_TRAINER, trainer.getName()),
+                result.getFeedbackToUser());
+        assertEquals(2, model.getFilteredClientList().size());
+        assertFalse(model.getSelectedTrainer().isEmpty());
+        assertEquals(trainer, model.getSelectedTrainer().get());
+    }
+
+    @Test
+    public void execute_withIndex_clearTrainerFlagIsFalse() throws CommandException {
+        Model model = new ModelManager(ab, new UserPrefs());
+        CommandResult result = new ListClientsCommand(Index.fromOneBased(1)).execute(model);
+        assertFalse(result.isClearTrainer());
+    }
+
+    @Test
+    public void execute_invalidIndex_throwsCommandException() {
+        Model model = new ModelManager(ab, new UserPrefs());
+        ListClientsCommand command = new ListClientsCommand(Index.fromOneBased(99));
+        assertThrows(CommandException.class, () -> command.execute(model));
+    }
+
+    // ──── Null model ──────────────────────────────────────────────────────────
+
+    @Test
     public void execute_nullModel_throwsNullPointerException() {
-        ListClientsCommand command = new ListClientsCommand();
-        assertThrows(NullPointerException.class, () -> command.execute(null));
+        assertThrows(NullPointerException.class, () -> new ListClientsCommand().execute(null));
+    }
+
+    // ──── Parser ─────────────────────────────────────────────────────────────
+
+    @Test
+    public void parser_emptyArgs_returnsNoIndexForm() throws ParseException {
+        ListClientsCommand cmd = new ListClientsCommandParser().parse("");
+        assertEquals(new ListClientsCommand(), cmd);
+    }
+
+    @Test
+    public void parser_validIndex_returnsIndexForm() throws ParseException {
+        ListClientsCommand cmd = new ListClientsCommandParser().parse("1");
+        assertEquals(new ListClientsCommand(Index.fromOneBased(1)), cmd);
+    }
+
+    @Test
+    public void parser_invalidIndex_throwsParseException() {
+        assertThrows(ParseException.class, () -> new ListClientsCommandParser().parse("abc"));
+    }
+
+    @Test
+    public void parser_zeroIndex_throwsParseException() {
+        assertThrows(ParseException.class, () -> new ListClientsCommandParser().parse("0"));
+    }
+
+    // ──── equals ─────────────────────────────────────────────────────────────
+
+    @Test
+    public void equals_sameNoIndex() {
+        assertEquals(new ListClientsCommand(), new ListClientsCommand());
+    }
+
+    @Test
+    public void equals_sameIndex() {
+        assertEquals(new ListClientsCommand(Index.fromOneBased(1)),
+                new ListClientsCommand(Index.fromOneBased(1)));
+    }
+
+    @Test
+    public void equals_differentForms() {
+        assertFalse(new ListClientsCommand().equals(new ListClientsCommand(Index.fromOneBased(1))));
     }
 }


### PR DESCRIPTION
The current list-clients command is incomplete as it does not clear the selected trainer in the UI, leading to a visual mismatch in the two-column layout. Additionally, the project lacks automated coverage enforcement, allowing potential regressions in test quality.

Let's enhance ListClientsCommand to support an optional trainer index for targeted filtering and ensure it clears the UI selection when called without arguments. This aligns the command's behavior with the existing 'Show All' button. Furthermore, we'll add a codecov.yml configuration to set a 75% coverage target, ensuring all future contributions maintain high testing standards.