### PR TITLE
Add import and export commands for address book data

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -1,0 +1,61 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.storage.JsonAddressBookStorage;
+
+/**
+ * Exports the address book to a specified JSON file.
+ */
+public class ExportCommand extends Command {
+
+    public static final String COMMAND_WORD = "export";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exports the address book to a specified JSON file.\n"
+            + "Parameters: FILE_PATH\n"
+            + "Example: " + COMMAND_WORD + " data/my_export.json";
+
+    public static final String MESSAGE_SUCCESS = "Address book exported successfully to: %1$s";
+    public static final String MESSAGE_EXPORT_FAILURE = "Failed to export address book to: %1$s. Error: %2$s";
+
+    private final Path filePath;
+
+    /**
+     * Creates an ExportCommand to export the AddressBook to the specified {@code Path}.
+     */
+    public ExportCommand(Path filePath) {
+        requireNonNull(filePath);
+        this.filePath = filePath;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        JsonAddressBookStorage storage = new JsonAddressBookStorage(filePath);
+        try {
+            storage.saveAddressBook(model.getAddressBook());
+            return new CommandResult(String.format(MESSAGE_SUCCESS, filePath.toString()));
+        } catch (IOException e) {
+            throw new CommandException(String.format(MESSAGE_EXPORT_FAILURE, filePath.toString(), e.getMessage()));
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof ExportCommand)) {
+            return false;
+        }
+
+        ExportCommand otherExportCommand = (ExportCommand) other;
+        return filePath.equals(otherExportCommand.filePath);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -1,0 +1,68 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import seedu.address.commons.exceptions.DataLoadingException;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.storage.JsonAddressBookStorage;
+
+/**
+ * Imports the address book from a specified JSON file.
+ */
+public class ImportCommand extends Command {
+
+    public static final String COMMAND_WORD = "import";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Imports the address book from a specified JSON file.\n"
+            + "Parameters: FILE_PATH\n"
+            + "Example: " + COMMAND_WORD + " data/my_import.json";
+
+    public static final String MESSAGE_SUCCESS = "Address book imported successfully from: %1$s";
+    public static final String MESSAGE_IMPORT_FAILURE = "Failed to import address book from: %1$s. Error: %2$s";
+    public static final String MESSAGE_FILE_NOT_FOUND = "Data file not found at: %1$s";
+
+    private final Path filePath;
+
+    /**
+     * Creates an ImportCommand to import the AddressBook from the specified {@code Path}.
+     */
+    public ImportCommand(Path filePath) {
+        requireNonNull(filePath);
+        this.filePath = filePath;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        JsonAddressBookStorage storage = new JsonAddressBookStorage(filePath);
+        try {
+            Optional<ReadOnlyAddressBook> addressBookOptional = storage.readAddressBook();
+            if (addressBookOptional.isEmpty()) {
+                throw new CommandException(String.format(MESSAGE_FILE_NOT_FOUND, filePath.toString()));
+            }
+            model.setAddressBook(addressBookOptional.get());
+            return new CommandResult(String.format(MESSAGE_SUCCESS, filePath.toString()));
+        } catch (DataLoadingException e) {
+            throw new CommandException(String.format(MESSAGE_IMPORT_FAILURE, filePath.toString(), e.getMessage()));
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof ImportCommand)) {
+            return false;
+        }
+
+        ImportCommand otherImportCommand = (ImportCommand) other;
+        return filePath.equals(otherImportCommand.filePath);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -16,10 +16,12 @@ import seedu.address.logic.commands.DeleteClientCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteTrainerCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.commands.FindClientsCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.FindTrainersCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.ListClientsCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListTrainersCommand;
@@ -121,6 +123,12 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ExportCommand.COMMAND_WORD:
+            return new ExportCommandParser().parse(arguments);
+
+        case ImportCommand.COMMAND_WORD:
+            return new ImportCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import seedu.address.logic.commands.ExportCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ExportCommand object
+ */
+public class ExportCommandParser implements Parser<ExportCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ExportCommand
+     * and returns an ExportCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ExportCommand parse(String args) throws ParseException {
+        String trimmedArgs = args == null ? "" : args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
+        }
+
+        try {
+            Path filePath = Paths.get(trimmedArgs);
+            return new ExportCommand(filePath);
+        } catch (InvalidPathException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import seedu.address.logic.commands.ImportCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ImportCommand object
+ */
+public class ImportCommandParser implements Parser<ImportCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ImportCommand
+     * and returns an ImportCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ImportCommand parse(String args) throws ParseException {
+        String trimmedArgs = args == null ? "" : args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+        }
+
+        try {
+            Path filePath = Paths.get(trimmedArgs);
+            return new ImportCommand(filePath);
+        } catch (InvalidPathException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+        }
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -1,0 +1,62 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class ExportCommandTest {
+
+    @TempDir
+    public Path testFolder;
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_exportSuccess() {
+        Path exportPath = testFolder.resolve("export.json");
+        ExportCommand exportCommand = new ExportCommand(exportPath);
+
+        String expectedMessage = String.format(ExportCommand.MESSAGE_SUCCESS, exportPath.toString());
+
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        assertCommandSuccess(exportCommand, model, expectedMessage, expectedModel);
+
+        // verify file was created
+        assertTrue(exportPath.toFile().exists());
+    }
+
+    @Test
+    public void equals() {
+        Path path1 = Path.of("path1.json");
+        Path path2 = Path.of("path2.json");
+        ExportCommand exportCommand1 = new ExportCommand(path1);
+        ExportCommand exportCommand2 = new ExportCommand(path2);
+
+        // same object -> returns true
+        assertTrue(exportCommand1.equals(exportCommand1));
+
+        // same values -> returns true
+        ExportCommand exportCommand1Copy = new ExportCommand(path1);
+        assertTrue(exportCommand1.equals(exportCommand1Copy));
+
+        // different types -> returns false
+        assertFalse(exportCommand1.equals(1));
+
+        // null -> returns false
+        assertFalse(exportCommand1.equals(null));
+
+        // different command -> returns false
+        assertFalse(exportCommand1.equals(exportCommand2));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -1,0 +1,88 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.storage.JsonAddressBookStorage;
+
+public class ImportCommandTest {
+
+    @TempDir
+    public Path testFolder;
+
+    @Test
+    public void execute_importSuccess() throws Exception {
+        // First, create a valid JSON file to import
+        Path importPath = testFolder.resolve("import.json");
+        JsonAddressBookStorage storage = new JsonAddressBookStorage(importPath);
+        storage.saveAddressBook(getTypicalAddressBook());
+
+        // Setup models
+        Model model = new ModelManager(); // empty model
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        ImportCommand importCommand = new ImportCommand(importPath);
+
+        String expectedMessage = String.format(ImportCommand.MESSAGE_SUCCESS, importPath.toString());
+
+        assertCommandSuccess(importCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_fileNotFound_throwsCommandException() {
+        Path importPath = testFolder.resolve("nonExistent.json");
+        ImportCommand importCommand = new ImportCommand(importPath);
+        Model model = new ModelManager();
+
+        String expectedMessage = String.format(ImportCommand.MESSAGE_FILE_NOT_FOUND, importPath.toString());
+
+        assertCommandFailure(importCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidFormat_throwsCommandException() throws Exception {
+        Path importPath = testFolder.resolve("invalid.json");
+        java.nio.file.Files.writeString(importPath, "invalid json content");
+
+        ImportCommand importCommand = new ImportCommand(importPath);
+        Model model = new ModelManager();
+
+        seedu.address.testutil.Assert.assertThrows(CommandException.class, () -> importCommand.execute(model));
+    }
+
+    @Test
+    public void equals() {
+        Path path1 = Path.of("path1.json");
+        Path path2 = Path.of("path2.json");
+        ImportCommand importCommand1 = new ImportCommand(path1);
+        ImportCommand importCommand2 = new ImportCommand(path2);
+
+        // same object -> returns true
+        assertTrue(importCommand1.equals(importCommand1));
+
+        // same values -> returns true
+        ImportCommand importCommand1Copy = new ImportCommand(path1);
+        assertTrue(importCommand1.equals(importCommand1Copy));
+
+        // different types -> returns false
+        assertFalse(importCommand1.equals(1));
+
+        // null -> returns false
+        assertFalse(importCommand1.equals(null));
+
+        // different command -> returns false
+        assertFalse(importCommand1.equals(importCommand2));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -20,10 +20,12 @@ import seedu.address.logic.commands.DeleteClientCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteTrainerCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.commands.FindClientsCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.FindTrainersCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.ListClientsCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListTrainersCommand;
@@ -119,6 +121,20 @@ public class AddressBookParserTest {
     public void parseCommand_exit() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
+    }
+
+    @Test
+    public void parseCommand_export() throws Exception {
+        ExportCommand command = (ExportCommand) parser.parseCommand(
+                ExportCommand.COMMAND_WORD + " data/export.json");
+        assertEquals(new ExportCommand(java.nio.file.Paths.get("data/export.json")), command);
+    }
+
+    @Test
+    public void parseCommand_import() throws Exception {
+        ImportCommand command = (ImportCommand) parser.parseCommand(
+                ImportCommand.COMMAND_WORD + " data/import.json");
+        assertEquals(new ImportCommand(java.nio.file.Paths.get("data/import.json")), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ExportCommand;
+
+public class ExportCommandParserTest {
+
+    private ExportCommandParser parser = new ExportCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsExportCommand() {
+        Path expectedPath = Paths.get("data/export.json");
+        assertParseSuccess(parser, "data/export.json", new ExportCommand(expectedPath));
+    }
+
+    @Test
+    public void parse_emptyArgs_throwsParseException() {
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ImportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ImportCommandParserTest.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ImportCommand;
+
+public class ImportCommandParserTest {
+
+    private ImportCommandParser parser = new ImportCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsImportCommand() {
+        Path expectedPath = Paths.get("data/import.json");
+        assertParseSuccess(parser, "data/import.json", new ImportCommand(expectedPath));
+    }
+
+    @Test
+    public void parse_emptyArgs_throwsParseException() {
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
AddressBook has no way to back up or restore data from external files.

Users may want to transfer data between devices or maintain backups outside the application's default storage.

Let's,
* add ExportCommand and ExportCommandParser to write the current AddressBook state to a specified JSON file path
* add ImportCommand and ImportCommandParser to load a ReadOnlyAddressBook from a specified JSON file, replacing the current application state
* wire both commands through AddressBookParser

Both commands delegate to JsonAddressBookStorage for actual file I/O. Import validates file existence and format before overwriting model data.

New test classes (ExportCommandTest, ImportCommandTest, ExportCommandParserTest, ImportCommandParserTest) are included and pass with the full Gradle test suite.