### PR TITLE
Fix import past validity dates

### DIFF
--- a/src/main/java/seedu/address/model/person/Validity.java
+++ b/src/main/java/seedu/address/model/person/Validity.java
@@ -14,6 +14,7 @@ import java.time.format.DateTimeParseException;
 public class Validity {
 
     public static final String MESSAGE_CONSTRAINTS = "Validity should be a valid date in the format YYYY-MM-DD.";
+    public static final String MESSAGE_PAST_DATE = "Validity date must not be in the past.";
 
     public final String value;
 
@@ -38,6 +39,14 @@ public class Validity {
         } catch (DateTimeParseException e) {
             return false;
         }
+    }
+
+    /**
+     * Returns true if the given validity date string is today or in the future.
+     * Must only be called after {@link #isValidValidity(String)} confirms the format is correct.
+     */
+    public static boolean isNotPastDate(String test) {
+        return !LocalDate.parse(test, DateTimeFormatter.ISO_LOCAL_DATE).isBefore(LocalDate.now());
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -253,6 +253,9 @@ class JsonAdaptedPerson {
         if (!Validity.isValidValidity(validity)) {
             throw new IllegalValueException(Validity.MESSAGE_CONSTRAINTS);
         }
+        if (!Validity.isNotPastDate(validity)) {
+            throw new IllegalValueException(Validity.MESSAGE_PAST_DATE);
+        }
         return Optional.of(new Validity(validity));
     }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -220,6 +220,13 @@ public class JsonAdaptedPersonTest {
         assertThrows(IllegalValueException.class, JsonAdaptedPerson.INVALID_TYPE_MESSAGE_FORMAT, person::toModelType);
     }
 
+    @Test
+    public void toModelType_pastValidity_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson("client", VALID_CLIENT_NAME, VALID_CLIENT_PHONE, null,
+                VALID_TRAINER_PHONE, VALID_TRAINER_NAME, 0, 0, null, null, "2000-01-01", VALID_TAGS);
+        assertThrows(IllegalValueException.class, Validity.MESSAGE_PAST_DATE, person::toModelType);
+    }
+
     private static class UnknownPerson extends Person {
         UnknownPerson(Name name, Phone phone, Set<Tag> tags) {
             super(name, phone, tags);


### PR DESCRIPTION
Fixes #145 

### Summary
Reject past validity dates during import.

### Details
- Added shared past-date validation in Validity
- Added validation in JsonAdaptedPerson.toModelValidity()
- Added test for past validity date during import

### Result
Imported data with a past validity date is now rejected with a clear error message.