### PR TITLE
Fix name validation for real-world names

### DIFF
--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,14 +10,15 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, it should not be blank, "
-            + "and should be no longer than 50 characters.";
+            "Names should only contain alphanumeric characters, spaces, hyphens, apostrophes, "
+            + "slashes, and periods, should not be blank, and should be no longer than 50 characters.";
 
     /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
+     * The first character must be alphanumeric (prevents leading spaces or symbols).
+     * Subsequent characters may also include hyphens, apostrophes, slashes, and periods
+     * to support real-world names such as Mary-Jane, O'Brien, Ravi s/o Kumar, J.K. Rowling.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} .'\\-/]*";
 
     private final String fullName;
 

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -27,8 +27,9 @@ public class NameTest {
         // invalid name
         assertFalse(Name.isValidName("")); // empty string
         assertFalse(Name.isValidName(" ")); // spaces only
-        assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
-        assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("^")); // unsupported symbol only
+        assertFalse(Name.isValidName("peter*")); // contains unsupported symbol
+        assertFalse(Name.isValidName("@lice")); // leading unsupported symbol
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
@@ -36,6 +37,10 @@ public class NameTest {
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(Name.isValidName("Mary-Jane")); // hyphenated name
+        assertTrue(Name.isValidName("O'Brien")); // name with apostrophe
+        assertTrue(Name.isValidName("Ravi s/o Kumar")); // s/o notation
+        assertTrue(Name.isValidName("J.K. Rowling")); // initials with periods
     }
 
     @Test


### PR DESCRIPTION
Fixes #149 

### Summary
Allow common real-world name formats in name validation.

### Details
- Updated `Name.VALIDATION_REGEX` to allow hyphens, apostrophes, slashes, and periods after the first character
- Updated `Name.MESSAGE_CONSTRAINTS` to match the new rule
- Added tests for common valid examples such as `Mary-Jane`, `O'Brien`, `Ravi s/o Kumar`, and `J.K. Rowling`

### Result
The app now accepts a wider range of realistic names while still rejecting unsupported symbols and blank names.