### PR TITLE
Fix find clearing selected trainer

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,10 +2,13 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Optional;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Trainer;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -29,7 +32,9 @@ public class FindCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        Optional<Trainer> selectedTrainer = model.getSelectedTrainer();
         model.updateFilteredPersonList(predicate);
+        selectedTrainer.ifPresent(model::setSelectedTrainer);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -9,13 +9,19 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.Trainer;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -69,6 +75,26 @@ public class FindCommandTest {
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(seedu.address.testutil.TypicalPersons.ALICE), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_preservesSelectedTrainer() throws Exception {
+        AddressBook ab = new AddressBook();
+        Trainer trainer = new Trainer(new Name("John"), new Phone("91234567"),
+                new Email("john@example.com"), new HashSet<>());
+        ab.addPerson(trainer);
+        Model model = new ModelManager(ab, new UserPrefs());
+
+        // Select the trainer before running find
+        model.setSelectedTrainer(trainer);
+        assertTrue(model.getSelectedTrainer().isPresent());
+
+        // Run find with a keyword that matches nothing
+        new FindCommand(preparePredicate("Nonexistent")).execute(model);
+
+        // Trainer selection must still be present
+        assertTrue(model.getSelectedTrainer().isPresent());
+        assertEquals(trainer, model.getSelectedTrainer().get());
     }
 
     @Test


### PR DESCRIPTION
Fixes #151 

### Summary
Prevent `find` from clearing the selected trainer.

### Details
- Saved the selected trainer before updating the filtered person list
- Restored the selection after filtering
- Added a test to verify trainer selection is preserved

### Result
Running `find` no longer clears the selected trainer as a side effect.