### PR TITLE
Help: fix multiple issues in help result display and window

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -11,7 +11,7 @@ import seedu.address.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "GymOps has been cleared!";
 
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -9,7 +9,7 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting GymOps as requested ...";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -12,28 +12,8 @@ public class HelpCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String SHOWING_HELP_MESSAGE = "Opened help window.\n\n"
-            + "Available commands:\n"
-            + "  add-trainer   — Add a new trainer\n"
-            + "  add-client    — Add a new client assigned to a trainer\n"
-            + "  delete-trainer — Delete a trainer\n"
-            + "  delete-client  — Delete a client\n"
-            + "  list          — List all persons\n"
-            + "  list-trainers — List all trainers\n"
-            + "  list-clients  — List all clients\n"
-            + "  stats         — View trainers sorted by number of clients\n"
-            + "  find          — Find persons by name\n"
-            + "  set-calorie-target — Set a client's calorie target\n"
-            + "  log-calorie-intake — Log a client's calorie intake\n"
-            + "  set-focus     — Set a client's workout focus\n"
-            + "  reassign-client — Reassign a client to a different trainer\n"
-            + "  remark        — Add a remark to a client\n"
-            + "  set-validity  — Set a client's membership validity\n"
-            + "  export        — Export the address book to a JSON file\n"
-            + "  import        — Import the address book from a JSON file\n"
-            + "  clear         — Clear all entries\n"
-            + "  help          — Show this help message\n"
-            + "  exit          — Exit the application";
+    public static final String SHOWING_HELP_MESSAGE =
+            "Help opened. Refer to the popup tab for the user guide.";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -18,37 +18,11 @@ public class HelpWindow extends UiPart<Stage> {
     public static final String USERGUIDE_URL = "https://ay2526s2-cs2103t-t17-1.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
-    public static final String COMMAND_SUMMARY_MESSAGE = ""
-            + "add-trainer n/NAME p/PHONE e/EMAIL\n"
-            + "add-client n/NAME p/PHONE t/TRAINER_INDEX [v/VALIDITY]\n"
-            + "edit-trainer INDEX [n/NAME] [p/PHONE] [e/EMAIL]\n"
-            + "edit-client INDEX [cal/CALORIES] [f/FOCUS] [r/REMARK] [v/VALIDITY]\n"
-            + "reassign-client CLIENT_INDEX t/TRAINER_INDEX\n"
-            + "\n"
-            + "delete-trainer INDEX\n"
-            + "delete-client INDEX\n"
-            + "delete t/TRAINER_INDEX  |  delete c/CLIENT_INDEX\n"
-            + "\n"
-            + "list  |  list-trainers  |  list-clients  |  stats\n"
-            + "find KEYWORD  |  find-trainers KEYWORD  |  find-clients KEYWORD\n"
-            + "\n"
-            + "set-calorie-target INDEX cal/CALORIES\n"
-            + "log-calorie INDEX cal/CALORIES\n"
-            + "set-focus c/CLIENT_INDEX f/FOCUS\n"
-            + "remark INDEX r/REMARK\n"
-            + "set-validity INDEX v/VALIDITY\n"
-            + "\n"
-            + "export FILE_PATH  |  import FILE_PATH\n"
-            + "clear  |  exit";
-
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
 
     @FXML
     private Button copyButton;
-
-    @FXML
-    private Label commandSummary;
 
     @FXML
     private Label helpMessage;
@@ -61,7 +35,6 @@ public class HelpWindow extends UiPart<Stage> {
     public HelpWindow(Stage root) {
         super(FXML, root);
         helpMessage.setText(HELP_MESSAGE);
-        commandSummary.setText(COMMAND_SUMMARY_MESSAGE);
     }
 
     /**

--- a/src/main/resources/view/HelpWindow.css
+++ b/src/main/resources/view/HelpWindow.css
@@ -15,15 +15,6 @@
     -fx-padding: 4 0 2 0;
 }
 
-#commandSummary {
-    -fx-text-fill: #e2e8f0;
-    -fx-font-family: "Consolas", "Courier New", monospace;
-    -fx-font-size: 12px;
-    -fx-background-color: #111124;
-    -fx-padding: 14;
-    -fx-background-radius: 4;
-}
-
 .help-url-row {
     -fx-background-color: #111124;
     -fx-background-radius: 4;

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -28,10 +28,6 @@
 
         <Label text="GymOps Help" styleClass="help-title" />
 
-        <Label text="COMMAND SUMMARY" styleClass="help-section-header" />
-
-        <Label fx:id="commandSummary" styleClass="help-commands" wrapText="true" />
-
         <Label text="USER GUIDE" styleClass="help-section-header" />
 
         <HBox alignment="CENTER_LEFT" spacing="10.0" styleClass="help-url-row">
@@ -40,7 +36,7 @@
           </padding>
           <Label fx:id="helpMessage" styleClass="help-url-label" wrapText="true" HBox.hgrow="ALWAYS" />
           <Button fx:id="copyButton" mnemonicParsing="false" onAction="#copyUrl"
-                  text="Copy URL" styleClass="help-copy-button" />
+                  text="Copy URL" styleClass="help-copy-button" minWidth="80" HBox.hgrow="NEVER" />
         </HBox>
 
       </VBox>


### PR DESCRIPTION
Help result display shows log-calorie-intake instead of log-calorie, omits 5 working commands (find-trainers, find-clients, edit-trainer, edit-client, delete), and retains AB3 branding in clear, exit, and export/import descriptions.

Help window command summary text is also cut off when the window is focused.

Let's,
* fix log-calorie-intake to log-calorie in help result display
* add missing commands to help result display command list
* replace all "Address book" references with "GymOps"
* fix command summary text cut off in help window when focused