### PR TITLE
Fix calorie commands, shorten command words, and sync docs to code

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -334,12 +334,12 @@ To keep the text readable, the flow is split into two smaller sequence diagrams.
 
 Other client attribute commands follow the same flow, with small differences:
 
-* `edit-client INDEX [cal/CALORIES] [f/FOCUS] [r/REMARK] [v/VALIDITY]` updates multiple client-only fields in one command.
+* `edit-c INDEX [cal/CALORIES] [f/FOCUS] [r/REMARK] [v/VALIDITY]` updates multiple client-only fields in one command.
    * For `f/`, `r/`, and `v/`, providing an empty value (e.g., `f/`) clears the corresponding optional field.
 * `remark INDEX r/REMARK` updates `Client#remark`.
-* `set-calorie-target INDEX cal/CALORIES` updates `Client#calorieTarget`.
-* `log-calorie INDEX cal/CALORIES` adds to `Client#calorieIntake` rather than overwriting it.
-* `reassign-client CLIENT_INDEX t/TRAINER_INDEX` reads both the filtered client list and filtered trainer list and updates `trainerPhone` + `trainerName`.
+* `set-cal c/INDEX cal/CALORIES` updates `Client#calorieTarget`. Use `cal/0` to clear the target.
+* `log-cal c/INDEX cal/CALORIES` adds to `Client#calorieIntake` rather than overwriting it.
+* `reassign-c CLIENT_INDEX t/TRAINER_INDEX` reads both the filtered client list and filtered trainer list and updates `trainerPhone` + `trainerName`.
 * `set-validity INDEX v/YYYY-MM-DD` updates `Client#validity`.
 
 #### Filtering Behaviour
@@ -350,7 +350,7 @@ As a result, the same client can have different indices depending on:
 * whether a trainer is currently selected (client list filtering), and
 * whether the user has applied `find-clients`.
 
-For `reassign-client`, the `CLIENT_INDEX` is resolved from the displayed client list and the `t/TRAINER_INDEX` is resolved from the displayed trainer list.
+For `reassign-c`, the `CLIENT_INDEX` is resolved from the displayed client list and the `t/TRAINER_INDEX` is resolved from the displayed trainer list.
 
 <div markdown="span" class="alert alert-warning">:warning: **Warning:** Filtering/selection means indices are *contextual*. A command that looks correct against the full list can target the wrong record if a `find-*` filter or selected-trainer filter is active.
 </div>
@@ -379,10 +379,10 @@ GymOps updates the client’s workout focus, persists the change, and the UI upd
 Step 3. The supervisor records an operational note using `remark 1 r/Recovering from ACL surgery`.
 GymOps overwrites any existing remark and updates the client card.
 
-Step 4. The supervisor sets a daily calorie target using `set-calorie-target 1 cal/2000`.
-GymOps updates the target and persists the change.
+Step 4. The supervisor sets a daily calorie target using `set-cal c/1 cal/2000`.
+GymOps updates the target and persists the change. To clear the target later, run `set-cal c/1 cal/0`.
 
-Step 5. The supervisor logs calorie intake throughout the day using `log-calorie 1 cal/500`.
+Step 5. The supervisor logs calorie intake throughout the day using `log-cal c/1 cal/500`.
 GymOps adds the new amount to the existing intake total.
 
 <div markdown="span" class="alert alert-info">:information_source: **Note:** The current version does not automatically reset intake totals by date.
@@ -853,7 +853,7 @@ The use cases below cover the user stories in the table above. Use cases that ar
 2.  GymOps shows a list of clients with index numbers.
 3.  Supervisor requests to list trainers.
 4.  GymOps shows a list of trainers with index numbers.
-5.  Supervisor issues the command to reassign a client to a new trainer (e.g., `reassign-client 2 t/1`).
+5.  Supervisor issues the command to reassign a client to a new trainer (e.g., `reassign-c 2 t/1`).
 6.  GymOps validates the input and updates the client’s assigned trainer.
 
    Use case ends.
@@ -1231,7 +1231,7 @@ The use cases below cover the user stories in the table above. Use cases that ar
 
 #### Performance
 
-1.  For a dataset of up to 100 trainers and 1000 clients, typical commands (e.g., `list`, `find`, `add-trainer`, `add-client`, `delete`, `set-calorie-target`, `log-calorie`, `set-focus`, `remark`) should complete within 1 second on a typical laptop.
+1.  For a dataset of up to 100 trainers and 1000 clients, typical commands (e.g., `list`, `find`, `add-t`, `add-c`, `delete`, `set-cal`, `log-cal`, `set-focus`, `remark`) should complete within 1 second on a typical laptop.
 
 #### Portability
 
@@ -1331,10 +1331,10 @@ testers are expected to do more *exploratory* testing.
 
    1. Prerequisites: List trainers using `list-trainers` and note a trainer that has assigned clients.
 
-   1. Test case: `edit-trainer 1 n/Alex Tan`<br>
+   1. Test case: `edit-t 1 n/Alex Tan`<br>
       Expected: Trainer at index 1 shows the updated name.
 
-   1. Test case: `edit-trainer 1 p/99998888`<br>
+   1. Test case: `edit-t 1 p/99998888`<br>
       Expected: Trainer at index 1 shows the updated phone.
       Also expected: Clients previously assigned to this trainer remain assigned (their stored trainer reference is updated to match the edited trainer).
 
@@ -1342,13 +1342,13 @@ testers are expected to do more *exploratory* testing.
 
    1. Prerequisites: List clients using `list-clients`.
 
-   1. Test case: `edit-client 1 n/Bob Lim p/98765432 t/1 cal/2000 f/Upper Body r/Note v/2027-01-01`<br>
+   1. Test case: `edit-c 1 n/Bob Lim p/98765432 t/1 cal/2000 f/Upper Body r/Note v/2027-01-01`<br>
       Expected: Client at index 1 shows updated details (including the optional fields).
 
-   1. Test case: `edit-client 1 f/ r/ v/`<br>
+   1. Test case: `edit-c 1 f/ r/ v/`<br>
       Expected: Client at index 1 has workout focus, remark, and validity cleared (removed from the client card display).
 
-   1. Other incorrect edit commands to try: `edit-trainer`, `edit-client`, `edit-client x n/Alice`, `edit-client 1 v/2000-01-01`<br>
+   1. Other incorrect edit commands to try: `edit-t`, `edit-c`, `edit-c x n/Alice`, `edit-c 1 v/2000-01-01`<br>
       Expected: Error shown indicating invalid command format or invalid values.
 
 ### Deleting a trainer/client
@@ -1420,14 +1420,14 @@ testers are expected to do more *exploratory* testing.
 
 1. Adding a trainer
 
-   1. Test case: `add-trainer n/Alex Tan p/91234567 e/alex@example.com`<br>
+   1. Test case: `add-t n/Alex Tan p/91234567 e/alex@example.com`<br>
       Expected: A new trainer appears in the trainer list.
 
 1. Adding a client
 
    1. Prerequisites: Ensure there is at least one trainer in the displayed trainer list.
 
-   1. Test case: `add-client n/Bob Lim p/98765432 t/1 v/2026-12-31`<br>
+   1. Test case: `add-c n/Bob Lim p/98765432 t/1 v/2026-12-31`<br>
       Expected: A new client appears in the client list and is assigned to trainer #1.
 
 ### Reassigning a client
@@ -1436,7 +1436,7 @@ testers are expected to do more *exploratory* testing.
 
    1. Prerequisites: Ensure there are at least 2 trainers and at least 1 client in the displayed lists.
 
-   1. Test case: `reassign-client 1 t/2`<br>
+   1. Test case: `reassign-c 1 t/2`<br>
       Expected: Client at index 1 shows their trainer updated to trainer #2.
 
 ### Calorie tracking
@@ -1445,14 +1445,17 @@ testers are expected to do more *exploratory* testing.
 
    1. Prerequisites: Ensure the displayed client list contains at least one client.
 
-   1. Test case: `set-calorie-target 1 cal/2000`<br>
+   1. Test case: `set-cal c/1 cal/2000`<br>
       Expected: The client card shows a calorie target (and a progress bar).
+
+   1. Test case: `set-cal c/1 cal/0`<br>
+      Expected: The calorie target is cleared for the 1st client.
 
 1. Logging calorie intake
 
    1. Prerequisites: Ensure the displayed client list contains at least one client.
 
-   1. Test case: `log-calorie 1 cal/500`<br>
+   1. Test case: `log-cal c/1 cal/500`<br>
       Expected: The client card shows an updated calorie intake total.
 
 ### Setting workout focus
@@ -1581,7 +1584,7 @@ GymOps is built on top of the AddressBook-Level3 (AB3) codebase. This allowed th
 ### Difficulty & Challenges
 
 * **Two list-centric entity types**: GymOps manages both trainers and clients as first-class entities, which increases complexity around filtering, index-based commands, and keeping UI lists consistent.
-* **Cross-list operations**: Commands such as `reassign-client` and `edit-client ... t/TRAINER_INDEX` resolve indices from different displayed lists, so correctness depends on clearly-defined “index is based on the current filtered list” behavior.
+* **Cross-list operations**: Commands such as `reassign-c` and `edit-c ... t/TRAINER_INDEX` resolve indices from different displayed lists, so correctness depends on clearly-defined “index is based on the current filtered list” behavior.
 * **Data integrity constraints**: Clients are assigned to exactly one trainer, and deleting trainers must respect this constraint (e.g., reject deletion if the trainer still has active clients).
 * **Persistence and compatibility**: Import/export and JSON storage need to persist all relevant fields, handle optional client attributes, and remain resilient to malformed or inconsistent data.
 * **Documentation accuracy**: Because behavior depends on filtered lists and selection state (e.g., `list-clients INDEX` selecting a trainer), documenting usage precisely required careful alignment with the implementation.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -45,16 +45,16 @@ This guide is written for **gym managers and administrators** who want a fast, k
     - [Saving data](#saving-data)
     - [Editing the data file](#editing-the-data-file)
   - [Trainer Management](#trainer-management)
-    - [Adding a trainer](#adding-a-trainer-add-trainer)
-    - [Editing a trainer](#editing-a-trainer-edit-trainer)
+    - [Adding a trainer](#adding-a-trainer-add-t)
+    - [Editing a trainer](#editing-a-trainer-edit-t)
     - [Listing all trainers](#listing-all-trainers-list-trainers)
     - [Finding trainers](#finding-trainers-find-trainers)
     - [Viewing trainer statistics](#viewing-trainer-statistics-stats)
     - [Deleting a trainer](#deleting-a-trainer-delete-trainer)
   - [Client Management](#client-management)
-    - [Adding a client](#adding-a-client-add-client)
-    - [Editing a client](#editing-a-client-edit-client)
-    - [Reassigning a client](#reassigning-a-client-reassign-client)
+    - [Adding a client](#adding-a-client-add-c)
+    - [Editing a client](#editing-a-client-edit-c)
+    - [Reassigning a client](#reassigning-a-client-reassign-c)
     - [Listing clients](#listing-clients-list-clients)
     - [Finding clients](#finding-clients-find-clients)
     - [Deleting a client](#deleting-a-client-delete-client)
@@ -99,9 +99,9 @@ This guide is written for **gym managers and administrators** who want a fast, k
    | Step | Command | What it does |
    |------|---------|-------------|
    | 1 | `list-trainers` | View all trainers |
-   | 2 | `add-trainer n/John Doe p/98765432 e/johndoe@example.com` | Add a new trainer |
+   | 2 | `add-t n/John Doe p/98765432 e/johndoe@example.com` | Add a new trainer |
    | 3 | `list-trainers` | Confirm the trainer was added |
-   | 4 | `add-client n/Alice Lim p/81234567 t/1 v/2028-09-09` | Assign a client to trainer #1 |
+   | 4 | `add-c n/Alice Lim p/81234567 t/1 v/2028-09-09` | Assign a client to trainer #1 |
    | 5 | `find-clients Alice` | Search for the client you just added |
    | 6 | `delete-client 1` | Delete the 1st client in the current list |
    | 7 | `clear` | Delete all data |
@@ -117,7 +117,7 @@ This guide is written for **gym managers and administrators** who want a fast, k
 
 **:information_source: Notes about the command format:**
 
-- Words in `UPPER_CASE` are parameters you supply. e.g. in `add-trainer n/NAME`, replace `NAME` with the actual name: `add-trainer n/John Doe`.
+- Words in `UPPER_CASE` are parameters you supply. e.g. in `add-t n/NAME`, replace `NAME` with the actual name: `add-t n/John Doe`.
 - Items in square brackets are optional. e.g. `find KEYWORD [MORE_KEYWORDS]` can be used as `find alice` or `find alice bob`.
 - Parameters can be in any order. e.g. `n/NAME p/PHONE_NUMBER` and `p/PHONE_NUMBER n/NAME` are both valid.
 - Extraneous parameters for commands that take no parameters (such as `help`, `list`, `exit`, and `clear`) will be ignored.
@@ -153,9 +153,9 @@ Format: `help`
 
 Shows all trainers and all clients.
 
-This command resets both lists to show all entries by:
-- clearing any active `find` filters, and
-- clearing any trainer selection made via the GUI (i.e. if you clicked a trainer to filter clients).
+This command resets both lists to show all entries by clearing any active `find` filters.
+
+<div markdown="span" class="alert alert-info">:bulb: **Tip:** To also clear a trainer selection made via the GUI, run `list-clients` (without an index) after `list`.</div>
 
 Format: `list`
 
@@ -299,14 +299,14 @@ Data is saved as a JSON file at `[JAR file location]/data/GymOps.json`. Advanced
 
 ### Trainer Management
 
-#### Adding a trainer: `add-trainer`
+#### Adding a trainer: `add-t`
 
 Adds a new trainer to GymOps.
 
-Format: `add-trainer n/NAME p/PHONE_NUMBER e/EMAIL`
+Format: `add-t n/NAME p/PHONE_NUMBER e/EMAIL`
 
 Examples:
-* `add-trainer n/John Doe p/98765432 e/johndoe@example.com`
+* `add-t n/John Doe p/98765432 e/johndoe@example.com`
 
 ![add trainer](images/addTrainer.png)
 **Expected outcome:** The new trainer is added to the **Trainers** panel, and a success message is displayed.
@@ -315,11 +315,11 @@ Examples:
 
 ---
 
-#### Editing a trainer: `edit-trainer`
+#### Editing a trainer: `edit-t`
 
 Edits the details of an existing trainer in GymOps. Use this command to update a trainer's name, phone number, or email address.
 
-Format: `edit-trainer INDEX [n/NAME] [p/PHONE] [e/EMAIL]`
+Format: `edit-t INDEX [n/NAME] [p/PHONE] [e/EMAIL]`
 
 * `INDEX` must be a positive integer.
 * At least one optional field must be provided.
@@ -328,8 +328,8 @@ Format: `edit-trainer INDEX [n/NAME] [p/PHONE] [e/EMAIL]`
 <div markdown="span" class="alert alert-info">:bulb: **Tip:** Run `list-trainers` to confirm the correct trainer index before editing.</div>
 
 Examples:
-* `edit-trainer 1 e/johndoe@gym.com` — updates the 1st trainer's email.
-* `edit-trainer 2 n/Jane Doe p/92222222` — updates the 2nd trainer's name and phone.
+* `edit-t 1 e/johndoe@gym.com` — updates the 1st trainer's email.
+* `edit-t 2 n/Jane Doe p/92222222` — updates the 2nd trainer's name and phone.
 
 ![edit trainer](images/editTrainer.png)
 
@@ -404,11 +404,11 @@ Examples:
 
 ### Client Management
 
-#### Adding a client: `add-client`
+#### Adding a client: `add-c`
 
 Adds a new client and assigns them to an existing trainer.
 
-Format: `add-client n/NAME p/PHONE_NUMBER t/TRAINER_INDEX [v/VALIDITY]`
+Format: `add-c n/NAME p/PHONE_NUMBER t/TRAINER_INDEX [v/VALIDITY]`
 
 * `TRAINER_INDEX` must refer to a trainer visible in the **current trainer list**.
 * `VALIDITY` is an optional field that must be a valid date in the format `YYYY-MM-DD`. e.g. `v/2028-09-09`. Using a wrong format such as `v/09-09-2028` will show: `Validity should be a valid date in the format YYYY-MM-DD.`
@@ -418,8 +418,8 @@ Format: `add-client n/NAME p/PHONE_NUMBER t/TRAINER_INDEX [v/VALIDITY]`
 <div markdown="span" class="alert alert-info">:bulb: **Tip:** Run `list-trainers` to confirm the correct trainer index before adding a client.</div>
 
 Examples:
-* `add-client n/Alice Lim p/81234567 t/1` — adds Alice Lim and assigns her to the 1st trainer in the list.
-* `add-client n/Alice Lim p/81234567 t/1 v/2028-09-09` — adds Alice Lim, assigns her to the 1st trainer, and sets her membership validity to 2028-09-09.
+* `add-c n/Alice Lim p/81234567 t/1` — adds Alice Lim and assigns her to the 1st trainer in the list.
+* `add-c n/Alice Lim p/81234567 t/1 v/2028-09-09` — adds Alice Lim, assigns her to the 1st trainer, and sets her membership validity to 2028-09-09.
 
 ![add client](images/addClient.png)
 **Expected outcome:** The new client is assigned to the specified trainer, added to the **Clients** panel, and a success message is displayed.
@@ -428,11 +428,11 @@ Examples:
 
 ---
 
-#### Editing a client: `edit-client`
+#### Editing a client: `edit-c`
 
 Edits the details of an existing client in GymOps. Use this command to update a client's name, phone number, assigned trainer, calorie target, workout focus, remark, or membership validity.
 
-Format: `edit-client INDEX [n/NAME] [p/PHONE] [t/TRAINER_INDEX] [cal/CALORIE_TARGET] [f/FOCUS] [r/REMARK] [v/VALIDITY]`
+Format: `edit-c INDEX [n/NAME] [p/PHONE] [t/TRAINER_INDEX] [cal/CALORIE_TARGET] [f/FOCUS] [r/REMARK] [v/VALIDITY]`
 
 * `INDEX` must be a positive integer.
 * At least one optional field must be provided.
@@ -442,19 +442,19 @@ Format: `edit-client INDEX [n/NAME] [p/PHONE] [t/TRAINER_INDEX] [cal/CALORIE_TAR
 <div markdown="span" class="alert alert-info">:bulb: **Tip:** Run `list-clients` to confirm the correct client index before editing.</div>
 
 Examples:
-* `edit-client 1 n/Alice Tan` — updates the 1st client's name to Alice Tan.
-* `edit-client 2 p/91234567 cal/2000` — updates the 2nd client's phone and calorie target.
-* `edit-client 1 t/2 f/Arms` — reassigns the 1st client to trainer #2 and sets focus to Arms.
+* `edit-c 1 n/Alice Tan` — updates the 1st client's name to Alice Tan.
+* `edit-c 2 p/91234567 cal/2000` — updates the 2nd client's phone and calorie target.
+* `edit-c 1 t/2 f/Arms` — reassigns the 1st client to trainer #2 and sets focus to Arms.
 
 [⬆ Back to top](#top)
 
 ---
 
-#### Reassigning a client: `reassign-client`
+#### Reassigning a client: `reassign-c`
 
 Reassigns an existing client to a different trainer. All client data (calorie target, intake, workout focus, remark) is preserved.
 
-Format: `reassign-client CLIENT_INDEX t/TRAINER_INDEX`
+Format: `reassign-c CLIENT_INDEX t/TRAINER_INDEX`
 
 * `CLIENT_INDEX` must refer to a client in the **client list**.
 * `TRAINER_INDEX` must refer to a trainer visible in the **current trainer list**.
@@ -462,7 +462,7 @@ Format: `reassign-client CLIENT_INDEX t/TRAINER_INDEX`
 <div markdown="span" class="alert alert-warning">:exclamation: **Caution:** If either list is filtered, indexes refer to the filtered results. Run `list` first to reassign using the full lists.</div>
 
 Examples:
-* `reassign-client 2 t/1` — reassigns the 2nd client to the 1st trainer.
+* `reassign-c 2 t/1` — reassigns the 2nd client to the 1st trainer.
 
 ![reassign client](images/reassignClient.png)
 **Expected outcome:** The client's assigned trainer is updated while preserving all other data. A success message is displayed.
@@ -539,10 +539,11 @@ Sets the daily calorie target for a client.
 Format: `set-cal c/CLIENT_INDEX cal/CALORIES`
 
 * `CLIENT_INDEX` must refer to a client in the **client list**.
-* `CALORIES` must be a positive integer.
+* `CALORIES` must be a non-negative integer. Use `0` to clear the calorie target.
 
 Examples:
 * `set-cal c/1 cal/2400` — sets a 2400-calorie daily target for the 1st client.
+* `set-cal c/1 cal/0` — clears the calorie target for the 1st client.
 
 ![set calorie](images/setCalorieTarget.png)
 
@@ -700,11 +701,11 @@ There is currently no CLI command to assign tags. Tags can only be added by edit
 | Action | Format | Example |
 |--------|--------|---------|
 | [**Help**](#viewing-help-help) | `help` | — |
-| [**Add trainer**](#adding-a-trainer-add-trainer) | `add-trainer n/NAME p/PHONE_NUMBER e/EMAIL` | `add-trainer n/John Doe p/98765432 e/johndoe@example.com` |
-| [**Edit trainer**](#editing-a-trainer-edit-trainer) | `edit-trainer INDEX [n/NAME] [p/PHONE] [e/EMAIL]` | `edit-trainer 1 n/Jane Doe e/jane@example.com` |
-| [**Add client**](#adding-a-client-add-client) | `add-client n/NAME p/PHONE_NUMBER t/TRAINER_INDEX [v/VALIDITY]` | `add-client n/Alice Lim p/81234567 t/1 v/2028-09-09` |
-| [**Edit client**](#editing-a-client-edit-client) | `edit-client INDEX [n/NAME] [p/PHONE] [t/TRAINER_INDEX] [cal/CALORIE_TARGET] [f/FOCUS] [r/REMARK] [v/VALIDITY]` | `edit-client 1 n/Alice Tan p/91234567` |
-| [**Reassign client**](#reassigning-a-client-reassign-client) | `reassign-client CLIENT_INDEX t/TRAINER_INDEX` | `reassign-client 2 t/1` |
+| [**Add trainer**](#adding-a-trainer-add-t) | `add-t n/NAME p/PHONE_NUMBER e/EMAIL` | `add-t n/John Doe p/98765432 e/johndoe@example.com` |
+| [**Edit trainer**](#editing-a-trainer-edit-t) | `edit-t INDEX [n/NAME] [p/PHONE] [e/EMAIL]` | `edit-t 1 n/Jane Doe e/jane@example.com` |
+| [**Add client**](#adding-a-client-add-c) | `add-c n/NAME p/PHONE_NUMBER t/TRAINER_INDEX [v/VALIDITY]` | `add-c n/Alice Lim p/81234567 t/1 v/2028-09-09` |
+| [**Edit client**](#editing-a-client-edit-c) | `edit-c INDEX [n/NAME] [p/PHONE] [t/TRAINER_INDEX] [cal/CALORIE_TARGET] [f/FOCUS] [r/REMARK] [v/VALIDITY]` | `edit-c 1 n/Alice Tan p/91234567` |
+| [**Reassign client**](#reassigning-a-client-reassign-c) | `reassign-c CLIENT_INDEX t/TRAINER_INDEX` | `reassign-c 2 t/1` |
 | [**List all**](#listing-all-persons-list) | `list` | — |
 | [**List trainers**](#listing-all-trainers-list-trainers) | `list-trainers` | — |
 | [**List clients**](#listing-clients-list-clients) | `list-clients [TRAINER_INDEX]` | `list-clients`, `list-clients 1` |
@@ -712,7 +713,7 @@ There is currently no CLI command to assign tags. Tags can only be added by edit
 | [**Find (both lists)**](#finding-persons-find) | `find KEYWORD [MORE_KEYWORDS]` | `find James Jake` |
 | [**Find trainers**](#finding-trainers-find-trainers) | `find-trainers KEYWORD [MORE_KEYWORDS]` | `find-trainers John` |
 | [**Find clients**](#finding-clients-find-clients) | `find-clients KEYWORD [MORE_KEYWORDS]` | `find-clients Alice` |
-| [**Set calorie target**](#setting-a-calorie-target-set-cal) | `set-cal c/CLIENT_INDEX cal/CALORIES` | `set-cal c/1 cal/2400` |
+| [**Set calorie target**](#setting-a-calorie-target-set-cal) | `set-cal c/CLIENT_INDEX cal/CALORIES` | `set-cal c/1 cal/2400`, `set-cal c/1 cal/0` |
 | [**Log calorie intake**](#logging-calorie-intake-log-cal) | `log-cal c/CLIENT_INDEX cal/CALORIES` | `log-cal c/1 cal/1500` |
 | [**Set workout focus**](#setting-a-workout-focus-set-focus) | `set-focus c/CLIENT_INDEX f/FOCUS` | `set-focus c/1 f/Chest` |
 | [**Remark**](#adding-a-remark-remark) | `remark c/CLIENT_INDEX r/REMARK` | `remark c/1 r/Recovering from ACL surgery` |

--- a/src/main/java/seedu/address/logic/commands/AddClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddClientCommand.java
@@ -26,7 +26,7 @@ import seedu.address.model.person.Validity;
  */
 public class AddClientCommand extends Command {
 
-    public static final String COMMAND_WORD = "add-client";
+    public static final String COMMAND_WORD = "add-c";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a new client and assigns them to a trainer.\n"
             + "Parameters: "

--- a/src/main/java/seedu/address/logic/commands/AddTrainerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTrainerCommand.java
@@ -14,7 +14,7 @@ import seedu.address.model.person.Trainer;
  */
 public class AddTrainerCommand extends Command {
 
-    public static final String COMMAND_WORD = "add-trainer";
+    public static final String COMMAND_WORD = "add-t";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a trainer to the gym's roster. "
             + "Parameters: "

--- a/src/main/java/seedu/address/logic/commands/EditClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditClientCommand.java
@@ -33,7 +33,7 @@ import seedu.address.model.person.exceptions.DuplicatePersonException;
  */
 public class EditClientCommand extends Command {
 
-    public static final String COMMAND_WORD = "edit-client";
+    public static final String COMMAND_WORD = "edit-c";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Edits the details of the client identified "

--- a/src/main/java/seedu/address/logic/commands/EditTrainerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditTrainerCommand.java
@@ -26,7 +26,7 @@ import seedu.address.model.person.exceptions.DuplicatePersonException;
  */
 public class EditTrainerCommand extends Command {
 
-    public static final String COMMAND_WORD = "edit-trainer";
+    public static final String COMMAND_WORD = "edit-t";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Edits the details of the trainer identified "

--- a/src/main/java/seedu/address/logic/commands/LogCalorieIntakeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LogCalorieIntakeCommand.java
@@ -37,8 +37,7 @@ public class LogCalorieIntakeCommand extends Command {
     public static final String MESSAGE_NOT_A_CLIENT =
             "The person at the specified index is not a Client.";
     public static final String MESSAGE_CALORIE_OVERFLOW =
-            "Cannot log calories: total intake would exceed the maximum allowed value (%d kcal). "
-            + "Please reset the client's calorie intake first.";
+            "Cannot log calories: that amount is too much — are you sure this is humanly possible?";
 
     private final Index targetIndex;
     private final int calories;
@@ -73,8 +72,7 @@ public class LogCalorieIntakeCommand extends Command {
         Client clientToEdit = (Client) personAtIndex;
         long newIntakeLong = (long) clientToEdit.getCalorieIntake() + calories;
         if (newIntakeLong > Integer.MAX_VALUE) {
-            throw new CommandException(
-                    String.format(MESSAGE_CALORIE_OVERFLOW, Integer.MAX_VALUE));
+            throw new CommandException(MESSAGE_CALORIE_OVERFLOW);
         }
         int newIntake = (int) newIntakeLong;
         Client updatedClient = clientToEdit.withCalorieIntake(newIntake);

--- a/src/main/java/seedu/address/logic/commands/ReassignClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ReassignClientCommand.java
@@ -19,7 +19,7 @@ import seedu.address.model.person.Trainer;
  */
 public class ReassignClientCommand extends Command {
 
-    public static final String COMMAND_WORD = "reassign-client";
+    public static final String COMMAND_WORD = "reassign-c";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Reassigns a client to a different trainer.\n"

--- a/src/main/java/seedu/address/logic/commands/SetCalorieTargetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetCalorieTargetCommand.java
@@ -27,11 +27,13 @@ public class SetCalorieTargetCommand extends Command {
             + " number used in the displayed client list.\n"
             + "Parameters: "
             + PREFIX_CLIENT + "CLIENT_INDEX "
-            + PREFIX_CALORIE + "CALORIES (must be a positive integer)\n"
+            + PREFIX_CALORIE + "CALORIES (must be a non-negative integer; use 0 to clear the target)\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_CLIENT + "1 " + PREFIX_CALORIE + "2000";
 
     public static final String MESSAGE_SET_CALORIE_TARGET_SUCCESS =
             "Set calorie target for %1$s: %2$d kcal/day";
+    public static final String MESSAGE_CLEAR_CALORIE_TARGET_SUCCESS =
+            "Calorie target cleared for %1$s";
     public static final String MESSAGE_NOT_A_CLIENT =
             "The person at the specified index is not a Client.";
 
@@ -69,8 +71,10 @@ public class SetCalorieTargetCommand extends Command {
         Client updatedClient = clientToEdit.withCalorieTarget(calorieTarget);
 
         model.setPerson(clientToEdit, updatedClient);
-        return new CommandResult(String.format(MESSAGE_SET_CALORIE_TARGET_SUCCESS,
-                updatedClient.getName(), calorieTarget));
+        String successMsg = calorieTarget == 0
+                ? String.format(MESSAGE_CLEAR_CALORIE_TARGET_SUCCESS, updatedClient.getName())
+                : String.format(MESSAGE_SET_CALORIE_TARGET_SUCCESS, updatedClient.getName(), calorieTarget);
+        return new CommandResult(successMsg);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -114,6 +114,21 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a {@code String calories} into a non-negative {@code int} calorie target.
+     * Accepts 0 (meaning "not set") or any positive integer.
+     *
+     * @throws ParseException if the given {@code calories} is not a non-negative integer.
+     */
+    public static int parseCalorieTarget(String calories) throws ParseException {
+        requireNonNull(calories);
+        String trimmed = calories.trim();
+        if (!trimmed.equals("0") && !StringUtil.isNonZeroUnsignedInteger(trimmed)) {
+            throw new ParseException("Calorie target must be a non-negative integer (use 0 to clear).");
+        }
+        return Integer.parseInt(trimmed);
+    }
+
+    /**
      * Parses {@code Collection<String> tags} into a {@code Set<Tag>}.
      */
     public static Set<Tag> parseTags(Collection<String> tags) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/SetCalorieTargetCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SetCalorieTargetCommandParser.java
@@ -41,7 +41,7 @@ public class SetCalorieTargetCommandParser implements Parser<SetCalorieTargetCom
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, SetCalorieTargetCommand.MESSAGE_USAGE), pe);
         }
 
-        int calorieTarget = ParserUtil.parseCalories(argMultimap.getValue(PREFIX_CALORIE).get());
+        int calorieTarget = ParserUtil.parseCalorieTarget(argMultimap.getValue(PREFIX_CALORIE).get());
 
         return new SetCalorieTargetCommand(index, calorieTarget);
     }

--- a/src/test/java/seedu/address/logic/parser/SetCalorieTargetCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SetCalorieTargetCommandParserTest.java
@@ -50,12 +50,12 @@ public class SetCalorieTargetCommandParserTest {
     @Test
     public void parse_invalidCalories_throwsParseException() {
         assertParseFailure(parser, " " + PREFIX_CLIENT + "1 " + PREFIX_CALORIE + INVALID_CALORIES,
-                "Calories must be a positive integer.");
+                "Calorie target must be a non-negative integer (use 0 to clear).");
     }
 
     @Test
-    public void parse_zeroCalories_throwsParseException() {
-        assertParseFailure(parser, " " + PREFIX_CLIENT + "1 " + PREFIX_CALORIE + "0",
-                "Calories must be a positive integer.");
+    public void parse_zeroCalories_returnsSetCalorieTargetCommand() {
+        assertParseSuccess(parser, " " + PREFIX_CLIENT + "1 " + PREFIX_CALORIE + "0",
+                new SetCalorieTargetCommand(INDEX_FIRST_PERSON, 0));
     }
 }


### PR DESCRIPTION
set-cal rejects cal/0 despite DG documenting it as valid for clearing the target. log-calorie overflow error exposes Integer.MAX_VALUE and references a non-existent reset command. Trainer and client command words are unnecessarily verbose. UG documents list as clearing trainer GUI selection, but ListCommand does not call clearSelectedTrainer().

Let's,
* add parseCalorieTarget() to accept 0 as a valid calorie target value
* update SetCalorieTargetCommand to treat cal/0 as a clear operation
* fix log-calorie overflow error to a user-friendly message
* rename add-trainer, edit-trainer to add-t, edit-t
* rename add-client, edit-client, reassign-client to add-c, edit-c, reassign-c
* correct UG list command description to match actual code behavior
* update all UG and DG references to reflect renamed commands