### PR TITLE
Fix: reject unknown prefixes in add-trainer parsing

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddTrainerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddTrainerCommandParser.java
@@ -26,6 +26,10 @@ public class AddTrainerCommandParser implements Parser<AddTrainerCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddTrainerCommand parse(String args) throws ParseException {
+        if (ArgumentTokenizer.hasUnknownPrefix(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTrainerCommand.MESSAGE_USAGE));
+        }
+
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL);
 

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -26,6 +27,31 @@ public class ArgumentTokenizer {
     public static ArgumentMultimap tokenize(String argsString, Prefix... prefixes) {
         List<PrefixPosition> positions = findAllPrefixPositions(argsString, prefixes);
         return extractArguments(argsString, positions);
+    }
+
+    /**
+     * Returns true if {@code argsString} contains any prefix-like token (of the form {@code [a-zA-Z]+/})
+     * that is not among the given {@code knownPrefixes}. Used to detect unknown prefixes before they
+     * are silently absorbed into an adjacent field's value.
+     *
+     * @param argsString   Arguments string to inspect
+     * @param knownPrefixes Prefixes that are valid for the current command
+     * @return             True if an unrecognised prefix-like token is present
+     */
+    public static boolean hasUnknownPrefix(String argsString, Prefix... knownPrefixes) {
+        Set<String> knownSet = Arrays.stream(knownPrefixes)
+                .map(Prefix::getPrefix)
+                .collect(Collectors.toSet());
+        for (String token : argsString.trim().split("\\s+")) {
+            int slashIdx = token.indexOf('/');
+            if (slashIdx > 0) {
+                String potentialPrefix = token.substring(0, slashIdx + 1);
+                if (potentialPrefix.matches("[a-zA-Z]+/") && !knownSet.contains(potentialPrefix)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddTrainerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddTrainerCommandParserTest.java
@@ -46,4 +46,10 @@ public class AddTrainerCommandParserTest {
         String expectedMessage = Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL);
         assertThrows(ParseException.class, expectedMessage, () -> parser.parse(" n/Alice p/67 e/a@b.com e/b@c.com"));
     }
+
+    @Test
+    public void parse_unknownPrefix_throwsParseException() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTrainerCommand.MESSAGE_USAGE);
+        assertThrows(ParseException.class, expectedMessage, () -> parser.parse(" n/John p/911 e/j@ee.com x/extra"));
+    }
 }


### PR DESCRIPTION
Fixes #232 

## Summary
Rejects unknown prefixes in `add-trainer` parsing so invalid parameters such as `x/extra` do not get absorbed into valid fields like email.

## Changes
- Added detection for unknown prefixes before tokenization
- Updated `AddTrainerCommandParser` to reject unknown prefixes cleanly
- Added parser test for unknown prefix input

## Rationale
Previously, unknown prefixes such as `x/` were not recognised and could be absorbed into the preceding field value, causing misleading validation failures. This fix ensures invalid prefixes are rejected directly.

## Testing
- `./gradlew checkstyleMain`
- `./gradlew test`
- `./gradlew clean build`

All checks pass.