### PR TITLE
Fix: enforce digits-only phone numbers to prevent duplicate bypass vi…

### DIFF
--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -10,9 +10,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Phone {
 
     public static final String MESSAGE_CONSTRAINTS =
-        "Phone numbers can contain numbers, spaces, '+', '-', '(', ')', must have at least 3 digits, "
-        + "and be no more than 20 characters in total.";
-    public static final String VALIDATION_REGEX = "[\\d\\s\\+\\-\\(\\)]+";
+        "Phone numbers must contain digits only, with at least 3 and no more than 20 digits.";
+    public static final String VALIDATION_REGEX = "\\d+";
     private final String value;
 
     /**

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -32,7 +32,7 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
 
         // valid phone numbers
-        assertTrue(Phone.isValidPhone("9312 1534")); // spaces within digits
+        assertFalse(Phone.isValidPhone("9312 1534")); // spaces not allowed
 
         // valid phone numbers
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers


### PR DESCRIPTION
Fixes #184 

## Summary
Prevents duplicate detection bypass caused by differently formatted phone numbers (e.g. `91234567` vs `9123 4567`) by enforcing digits-only phone input.

## Changes
- Restricted phone number validation to digits only
- Updated validation message to reflect new constraint
- Updated test to reject phone numbers with spaces

## Rationale
Previously, the app accepted phone numbers with spaces or symbols, causing logically identical numbers to be treated as different values. This allowed duplicate entries to bypass detection. Enforcing digits-only input ensures consistent representation.

## Testing
- `./gradlew checkstyleMain`
- `./gradlew test`
- `./gradlew clean build`

All checks pass.